### PR TITLE
Add Docker capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2-alpine
+
+COPY . /zero_log_parser
+WORKDIR /zero_log_parser
+
+RUN python setup.py develop \
+&&  mv /zero_log_parser/docker-entrypoint.sh /usr/bin
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,47 @@ You'll need to install Python 2 somehow from https://www.python.org/downloads/
 
 `$ python zero_log_parser.py <*.bin file> [-o output_file]`
 
+### Docker
+If you want to run using Docker, there's only two steps: build, then run.
+
+#### Docker Build
+```
+docker build . -t "zero-log-parser"
+```
+
+To explain:
+
+`docker build` = Build a new Docker image
+
+`.` = Use a Dockerfile in the current directory ("/.")
+
+`-t "zero-log-parser"` = Tag it as "zero-log-parser"
+
+#### Docker Run
+
+We will change directory to where the logs are stored, then run the tool against a log.
+
+```
+cd ~/zero-logs
+docker run --rm -v "$PWD:/root" zero-log-parser /root/VIN_BMS0_2019-04-20.bin -o /root/VIN_BMS0_2019-04-20.txt
+```
+
+To explain:
+
+`cd ~/zero-logs` = Go to the directory where the logs are stored.  Change this to the correct directory for you
+
+`docker run` = Run a Docker image as a container
+
+`--rm` = Don't keep the image when it exits
+
+`-v "$PWD:/root"` = Mount the current working directory as a volume inside the container at /root
+
+`zero-log-parser` = What Docker image to run
+
+`/root/VIN_BMS0_2019-04-20.bin` = Name of the binary file.  You can get this by doing an `ls` after the `cd` before this command.  Make sure to add /root/ before it since the path in the container is different
+
+`-o /root/VIN_BMS0_2019-04-20.txt` = Save the decoded log file as VIN_BMS0_2019-04-20.txt in /root, which will save it in the current working directory outside of the container
+
 ## Development
 Basic log documentation is at [log_structure.md](log_structure.md).
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -z $1 ]; then
+  python zero_log_parser.py -h
+else
+  python zero_log_parser.py $@
+fi


### PR DESCRIPTION
This PR adds Docker capabilities to the tool.  Using Docker, you don't need any other dependencies to run the tool, Docker takes care of all of that when it builds the image.  The whole image for this tool is only about 64MB.

It's also possible to build this image for others and share it on Docker Hub.  Then the users don't even need to build it themselves, all they need is Docker and they can run it using one command:

`docker run tyzbit/zero-log-parser`

This actually works right now.  It's just something quick I created, so it could be re-created using a different account at `zeromc/zero-log-parser` or something like that.

Another benefit of using Docker is making it easier to test code changes and run tests against the code as you can create new images with different versions of the code in seconds.